### PR TITLE
Configuring the default variables to allow multiple 1 or more virtualhosts

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,6 @@
 ---
 apache:
-    docroot: "/vagrant"
-    servername: "myApp.vb"
+    hosts:
+      - docroot: '/vagrant'
+        servername: 'myApp.vb'
+        config_name: '000-default.conf'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -26,7 +26,7 @@
   become: yes
   template: src=vhost24.conf.tpl dest=/etc/apache2/sites-available/{{ item.config_name }}
   notify: restart apache
-  when: apache_version.stdout.find('Apache/2.4.') != -1
+  when: apache_version.stdout.find('Apache/2.4.') != -1 and item.config_name is defined
   with_items:
     - "{{ apache.hosts }}"
 
@@ -34,6 +34,6 @@
   become: yes
   template: src=vhost22.conf.tpl dest=/etc/apache2/sites-available/{{ item.config_name }}
   notify: restart apache
-  when: apache_version.stdout.find('Apache/2.2.') != -1
+  when: apache_version.stdout.find('Apache/2.2.') != -1 and item.config_name is defined
   with_items:
     - "{{ apache.hosts }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -24,12 +24,16 @@
 
 - name: Change default apache2.4 site
   become: yes
-  template: src=vhost24.conf.tpl dest=/etc/apache2/sites-available/000-default.conf
+  template: src=vhost24.conf.tpl dest=/etc/apache2/sites-available/{{ item.config_name }}
   notify: restart apache
   when: apache_version.stdout.find('Apache/2.4.') != -1
+  with_items:
+    - "{{ apache.hosts }}"
 
 - name: Change default apache2.2 site
   become: yes
-  template: src=vhost22.conf.tpl dest=/etc/apache2/sites-available/default
+  template: src=vhost22.conf.tpl dest=/etc/apache2/sites-available/{{ item.config_name }}
   notify: restart apache
   when: apache_version.stdout.find('Apache/2.2.') != -1
+  with_items:
+    - "{{ apache.hosts }}"

--- a/templates/vhost22.conf.tpl
+++ b/templates/vhost22.conf.tpl
@@ -2,10 +2,10 @@
 
 <VirtualHost *:80>
     ServerAdmin webmaster@localhost
-    DocumentRoot {{ apache.docroot }}
-    ServerName {{ apache.servername }}
+    DocumentRoot {{ item.docroot }}
+    ServerName {{ item.servername }}
 
-    <Directory {{ apache.docroot }}>
+    <Directory {{ item.docroot }}>
         AllowOverride All
         Options -Indexes FollowSymLinks
         Order allow,deny

--- a/templates/vhost24.conf.tpl
+++ b/templates/vhost24.conf.tpl
@@ -2,10 +2,10 @@
 
 <VirtualHost *:80>
     ServerAdmin webmaster@localhost
-    DocumentRoot {{ apache.docroot }}
-    ServerName {{ apache.servername }}
+    DocumentRoot {{ item.docroot }}
+    ServerName {{ item.servername }}
 
-    <Directory {{ apache.docroot }}>
+    <Directory {{ item.docroot }}>
         AllowOverride All
         Options -Indexes +FollowSymLinks
         Require all granted


### PR DESCRIPTION
There was an issue in the Phansible/Phansible repository (#282) asking how to set up multiple virtualhosts. Having done something similar in our Ansible setup, I'd like to propose the following changes.

`default/main.yml` - alter the yaml structure to include a hosts section, by default it will work the same way as it did before. This also allows some flexibility to set apache level variables, as well as variables at the vhost level. Also provided a `config_name` option that will allow a user to set the name of the file that will go in `/etc/apache2/sites-available`

`tasks/main.yml` - Modify the 2.4 and 2.2 tasks to use the items in `apache.hosts` to build the virtual hosts and use the `{{ item.config_name }}` value to name the vhost file.

`templates/vhost22.yml & templates/vhost24.yml` - Since we are looping through the hosts, on each pass the `item` will be available, in order for these to be configured correctly - had to change the `apache.docroot` and `apache.servername` tokens with `item.docroot` and `item.servername`.

Since the default variables will be overwritten by anything, setting up the default variables this way provides a little bit of structure if a user wanted to change where they are using variables
